### PR TITLE
Implement publish-subscribe model for APEX with unittests for verification

### DIFF
--- a/apex/python/manager.py
+++ b/apex/python/manager.py
@@ -1,7 +1,7 @@
 from python.publisher import Publisher
 from python.subscriber import Subscriber
 from typing import Dict
-from log import Logger
+from python.log import Logger
 import logging
 
 class EventManager(Publisher):

--- a/apex/python/manager.py
+++ b/apex/python/manager.py
@@ -54,5 +54,5 @@ class EventManager(Publisher):
     
     # API Endpoint for Upstream to inform subscribers 
     # that their Event Source (Tacos Object) is finished
-    def finish(self) -> None:
-        self.notify_finish()
+    def finish(self, id: int) -> None:
+        self.notify_finish(id)

--- a/apex/python/manager.py
+++ b/apex/python/manager.py
@@ -1,5 +1,5 @@
-from publisher import Publisher
-from subscriber import Subscriber
+from python.publisher import Publisher
+from python.subscriber import Subscriber
 from typing import Dict
 
 class EventManager(Publisher):
@@ -18,18 +18,35 @@ class EventManager(Publisher):
     
     # Remove subscriber
     def detach(self, id: int, subscriber: Subscriber) -> None:
-        if id in self._subscribers:
+        if id in self._subscribers and subscriber in self._subscribers[id]:
             self._subscribers[id].remove(subscriber)
-    
-    # API Endpoint for Upstream
-    def forward_event(self, id: int, event: Dict) -> None:
-        for subscriber in self._subscribers[id]:
-            subscriber.update(event)
+            if not self._subscribers[id]:  # Optionally, clean up empty lists
+                del self._subscribers[id]
 
-    # Notify subscribers of incoming event
+    # Notify subscribers of an event
     def notify(self, event: Dict) -> None:
-        # Extract id from event
-        id = event['id']
+        id = event.get('id')
+        if id in self._subscribers:
+            for subscriber in self._subscribers[id]:
+                subscriber.update(event)
+        else:
+            # Handle missing id in subscribers, maybe log a warning
+            pass
 
-        # Forward Event downstream
-        self.forward_event(id, event)
+    # Notify subscribers that this publisher is done
+    def notify_finish(self, id: int) -> None:
+        if id in self._subscribers:
+            for subscriber in self._subscribers[id]:
+                subscriber.finish()
+
+                # remove subscriber
+                self.detach(1, subscriber)
+    
+    # API Endpoint for Upstream to notify subscribers of an event
+    def forward_event(self, event: Dict) -> None:
+        self.notify(event=event)
+    
+    # API Endpoint for Upstream to inform subscribers 
+    # that their Event Source (Tacos Object) is finished
+    def finish(self) -> None:
+        self.notify_finish()

--- a/apex/python/manager.py
+++ b/apex/python/manager.py
@@ -54,5 +54,5 @@ class EventManager(Publisher):
     
     # API Endpoint for Upstream to inform subscribers 
     # that their Event Source (Tacos Object) is finished
-    def finish(self, id: int) -> None:
-        self.notify_finish(id)
+    def finish(self) -> None:
+        self.notify_finish()

--- a/apex/python/manager.py
+++ b/apex/python/manager.py
@@ -54,5 +54,5 @@ class EventManager(Publisher):
     
     # API Endpoint for Upstream to inform subscribers 
     # that their Event Source (Tacos Object) is finished
-    def finish(self) -> None:
-        self.notify_finish()
+    def finish(self, id) -> None:
+        self.notify_finish(id)

--- a/apex/python/publisher.py
+++ b/apex/python/publisher.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from subscriber import Subscriber
+from python.subscriber import Subscriber
 from typing import Dict
 
 # Define a generic Publisher

--- a/apex/python/publisher.py
+++ b/apex/python/publisher.py
@@ -29,6 +29,13 @@ class Publisher(ABC):
     @abstractmethod
     def notify(self, event: Dict) -> None:
         """
-        Notify subscriber about an event
+        Notify subscribers about an event
+        """
+        pass
+
+    @abstractmethod
+    def notify_finish(self, id: int) -> None:
+        """
+        Notify subscribers that this publisher is done
         """
         pass

--- a/apex/python/subscriber.py
+++ b/apex/python/subscriber.py
@@ -3,13 +3,19 @@ from abc import ABC, abstractmethod
 from typing import Dict
 
 class Subscriber(ABC):
-    """
+    '''
     The Subscriber interface declares the update method, used by publishers.
-    """
+    '''
 
     @abstractmethod
     def update(self, event: Dict) -> None:
-        """
-            Receive update from publisher.
-        """
+        '''
+        Receive update from publisher.
+        '''
         pass
+
+    @abstractmethod
+    def finish(self) -> None:
+        '''
+        Subscriber does some logic after Event Source is finished
+        '''

--- a/apex/unittests/test_event_manager.py
+++ b/apex/unittests/test_event_manager.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import Mock
+from typing import Dict
+from python.subscriber import Subscriber
+from python.manager import EventManager
+
+class TestEventManager(unittest.TestCase):
+    
+    def setUp(self):
+        self.event_manager = EventManager()
+        self.subscriber = Mock(spec=Subscriber) # Mock a subscriber class without a concrete implementation
+        self.event = {'id': 1, 'data': 'test event'}
+
+    def test_attach_subscriber(self):
+        # Act
+        self.event_manager.attach(1, self.subscriber)
+        
+        # Assert
+        self.assertIn(1, self.event_manager._subscribers)
+        self.assertIn(self.subscriber, self.event_manager._subscribers[1])
+
+    def test_detach_subscriber(self):
+        # Arrange
+        self.event_manager.attach(1, self.subscriber)
+        
+        # Act
+        self.event_manager.detach(1, self.subscriber)
+        
+        # Assert
+        self.assertNotIn(1, self.event_manager._subscribers)
+
+    def test_notify_subscribers(self):
+        # Arrange
+        self.event_manager.attach(1, self.subscriber)
+        
+        # Act
+        self.event_manager.forward_event(self.event)
+        
+        # Assert
+        self.subscriber.update.assert_called_with(self.event)
+
+    def test_notify_finish(self):
+        # Arrange
+        self.event_manager.attach(1, self.subscriber)
+        
+        # Act
+        self.event_manager.notify_finish(1)
+        
+        # Assert
+        self.subscriber.finish.assert_called()
+        self.assertNotIn(1, self.event_manager._subscribers)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apex/unittests/test_publisher.py
+++ b/apex/unittests/test_publisher.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import Mock
+from typing import Dict
+from python.publisher import Publisher
+from python.subscriber import Subscriber
+
+
+class ConcretePublisher(Publisher):
+    def attach(self, id: int, subscriber: Subscriber) -> None:
+        if id not in self._subscribers:
+            self._subscribers[id] = []
+        self._subscribers[id].append(subscriber)
+
+    def detach(self, id: int, subscriber: Subscriber) -> None:
+        if id in self._subscribers:
+            self._subscribers[id].remove(subscriber)
+            if not self._subscribers[id]:
+                del self._subscribers[id]
+
+    def notify(self, event: Dict) -> None:
+        id = event.get('id')
+        if id in self._subscribers:
+            for subscriber in self._subscribers[id]:
+                subscriber.update(event)
+
+    def notify_finish(self, id: int) -> None:
+        if id in self._subscribers:
+            for subscriber in self._subscribers[id]:
+                subscriber.finish()
+                
+                # remove subscriber
+                self.detach(1, subscriber)
+
+class TestPublisher(unittest.TestCase):
+    
+    def setUp(self):
+        self.publisher = ConcretePublisher()
+        self.subscriber = Mock(spec=Subscriber)
+        self.event = {'id': 1, 'data': 'test event'}
+
+    def test_attach_subscriber(self):
+        # Act
+        self.publisher.attach(1, self.subscriber)
+        
+        # Assert
+        self.assertIn(1, self.publisher._subscribers)
+        self.assertIn(self.subscriber, self.publisher._subscribers[1])
+
+    def test_detach_subscriber(self):
+        # Arrange
+        self.publisher.attach(1, self.subscriber)
+        
+        # Act
+        self.publisher.detach(1, self.subscriber)
+        
+        # Assert
+        self.assertNotIn(1, self.publisher._subscribers)
+
+    def test_notify_subscribers(self):
+        # Arrange
+        self.publisher.attach(1, self.subscriber)
+        
+        # Act
+        self.publisher.notify(self.event)
+        
+        # Assert
+        self.subscriber.update.assert_called_with(self.event)
+
+    def test_notify_finish(self):
+        # Arrange
+        self.publisher.attach(1, self.subscriber)
+        
+        # Act
+        self.publisher.notify_finish(1)
+        
+        # Assert
+        self.subscriber.finish.assert_called()
+        self.assertNotIn(1, self.publisher._subscribers)

--- a/apex/unittests/test_subscriber.py
+++ b/apex/unittests/test_subscriber.py
@@ -1,0 +1,39 @@
+import unittest
+from typing import Dict
+from python.subscriber import Subscriber
+
+class TestSubscriber(unittest.TestCase):
+    
+    def test_subscriber_update(self):
+        class ConcreteSubscriber(Subscriber):
+            def update(self, event: Dict) -> None:
+                self.received_event = event
+            
+            def finish(self) -> None:
+                pass
+
+        subscriber = ConcreteSubscriber()
+        event = {'id': 1, 'data': 'test event'}
+        
+        # Act
+        subscriber.update(event)
+        
+        # Assert
+        self.assertEqual(subscriber.received_event, event)
+
+    def test_subscriber_finish(self):
+        class ConcreteSubscriber(Subscriber):
+            def update(self, event: Dict) -> None:
+                pass
+            
+            def finish(self) -> None:
+                self.finished = True
+
+        subscriber = ConcreteSubscriber()
+        
+        # Act
+        subscriber.finish()
+        
+        # Assert
+        self.assertTrue(hasattr(subscriber, 'finished'))
+        self.assertTrue(subscriber.finished)


### PR DESCRIPTION
### Summary
This PR address #3 by implementing a publish-subscribe model for the APEX Backend framework. It introduces the following contributions:

- Implement a `Publisher` interface to publish events to subscribers
- Implement `Subscriber` interface to process events from publishers
- An `EventManager` which is the top-level publisher for APEX
   - This will create (in future) in the pipeline per Tacos Greedy Object
   - Implement the subscription mechanism between the pipeline and associated tacos object
   - Exposes API Endpoints for upstream (Tacos library) to use to call methods for forwarding events and finishing publishing events

### Test
Implement the following 3 unit-tests:
- test_subscriber.py
   - This class tests a basic implementation of the `Subscriber` interface to ensure that the update and finish methods are correctly implemented.
- test_publisher.py
   - This class tests a concrete implementation of the `Publisher` abstract class. It checks that subscribers are correctly attached, detached, notified of events, and notified when events are finished.
- test_event_manager.py
   - This class tests the `EventManager` class, which is a specific implementation of `Publisher`. It ensures that the `EventManager` behaves correctly when forwarding events to subscribers and notifying them of event completion.

Run the following: `python -m unittest discover -s unittests`